### PR TITLE
Update Site-Wide Settings

### DIFF
--- a/docs/site.json
+++ b/docs/site.json
@@ -1,7 +1,7 @@
 {
   "baseUrl": "",
-  "titlePrefix": "RecruitTrackPro",
-  "titleSuffix": "AddressBook Level-3",
+  "titlePrefix": "",
+  "titleSuffix": "RecruitTrackPro",
   "faviconPath": "images/SeEduLogo.png",
   "style": {
     "codeTheme": "light"


### PR DESCRIPTION
Fixes #60 
Remove the `titlePrefix` and update `titleSuffix` to our product name, resulting in `User Guide - RecruitTrackPro`.