### PR TITLE
Add the "--contain-all" option for "find" command

### DIFF
--- a/src/main/java/seedu/recruittrackpro/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/recruittrackpro/logic/commands/FindCommand.java
@@ -18,7 +18,7 @@ public class FindCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all persons whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
-            + "Parameters: " + PREFIX_NAME + "KEYWORD [MORE_KEYWORDS]...\n"
+            + "Parameters: [--contain-all] " + PREFIX_NAME + "KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "alice bob charlie";
 
     private final NameContainsKeywordsPredicate predicate;

--- a/src/main/java/seedu/recruittrackpro/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/recruittrackpro/logic/parser/FindCommandParser.java
@@ -26,8 +26,11 @@ public class FindCommandParser implements Parser<FindCommand> {
         requireNonNull(args);
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
 
+        String preamble = argMultimap.getPreamble();
+        boolean shouldContainAll = preamble.equals("--contain-all");
+
         if (!hasAtLeastOnePrefixPresent(argMultimap, PREFIX_NAME)
-                || !argMultimap.getPreamble().isEmpty()) {
+                || (!preamble.isEmpty() && !shouldContainAll)) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, FindCommand.MESSAGE_USAGE));
         }
@@ -40,8 +43,7 @@ public class FindCommandParser implements Parser<FindCommand> {
         }
 
         String[] nameKeywords = name.split("\\s+");
-
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords), shouldContainAll));
     }
 
     /**

--- a/src/main/java/seedu/recruittrackpro/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/recruittrackpro/model/person/NameContainsKeywordsPredicate.java
@@ -11,13 +11,22 @@ import seedu.recruittrackpro.commons.util.ToStringBuilder;
  */
 public class NameContainsKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
+    private final boolean shouldContainAll;
 
-    public NameContainsKeywordsPredicate(List<String> keywords) {
+    /**
+     * Constructs a  {@code NameContainsKeywordsPredicate} with the specified options.
+     */
+    public NameContainsKeywordsPredicate(List<String> keywords, boolean shouldContainAll) {
         this.keywords = keywords;
+        this.shouldContainAll = shouldContainAll;
     }
 
     @Override
     public boolean test(Person person) {
+        if (shouldContainAll) {
+            return keywords.stream()
+                    .allMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
+        }
         return keywords.stream()
                 .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));
     }

--- a/src/main/java/seedu/recruittrackpro/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/recruittrackpro/model/person/NameContainsKeywordsPredicate.java
@@ -43,11 +43,14 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
         }
 
         NameContainsKeywordsPredicate otherNameContainsKeywordsPredicate = (NameContainsKeywordsPredicate) other;
-        return keywords.equals(otherNameContainsKeywordsPredicate.keywords);
+        return keywords.equals(otherNameContainsKeywordsPredicate.keywords)
+                && (shouldContainAll == otherNameContainsKeywordsPredicate.shouldContainAll);
     }
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("keywords", keywords).toString();
+        return new ToStringBuilder(this)
+                .add("keywords", keywords)
+                .add("shouldContainAll", shouldContainAll).toString();
     }
 }

--- a/src/main/java/seedu/recruittrackpro/model/person/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/recruittrackpro/model/person/NameContainsKeywordsPredicate.java
@@ -23,6 +23,9 @@ public class NameContainsKeywordsPredicate implements Predicate<Person> {
 
     @Override
     public boolean test(Person person) {
+        if (keywords.isEmpty()) {
+            return false;
+        }
         if (shouldContainAll) {
             return keywords.stream()
                     .allMatch(keyword -> StringUtil.containsWordIgnoreCase(person.getName().fullName, keyword));

--- a/src/test/java/seedu/recruittrackpro/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/recruittrackpro/logic/commands/CommandTestUtil.java
@@ -120,7 +120,7 @@ public class CommandTestUtil {
 
         Person person = model.getFilteredPersonList().get(targetIndex.getZeroBased());
         final String[] splitName = person.getName().fullName.split("\\s+");
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0]), false));
 
         assertEquals(1, model.getFilteredPersonList().size());
     }

--- a/src/test/java/seedu/recruittrackpro/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/recruittrackpro/logic/commands/FindCommandTest.java
@@ -30,9 +30,9 @@ public class FindCommandTest {
     @Test
     public void equals() {
         NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
+                new NameContainsKeywordsPredicate(Collections.singletonList("first"), false);
         NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+                new NameContainsKeywordsPredicate(Collections.singletonList("second"), false);
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -76,7 +76,7 @@ public class FindCommandTest {
 
     @Test
     public void toStringMethod() {
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"));
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("keyword"), false);
         FindCommand findCommand = new FindCommand(predicate);
         String expected = FindCommand.class.getCanonicalName() + "{predicate=" + predicate + "}";
         assertEquals(expected, findCommand.toString());
@@ -86,6 +86,6 @@ public class FindCommandTest {
      * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
      */
     private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")), false);
     }
 }

--- a/src/test/java/seedu/recruittrackpro/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/recruittrackpro/logic/parser/FindCommandParserTest.java
@@ -40,6 +40,11 @@ public class FindCommandParserTest {
 
         // multiple whitespaces between keywords
         assertParseSuccess(parser, " " + PREFIX_NAME + " \n Alice \n \t Bob  \t", expectedFindCommand);
+
+        // --contain-all option
+        expectedFindCommand =
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"), true));
+        assertParseSuccess(parser, "--contain-all " + PREFIX_NAME + "Alice Bob", expectedFindCommand);
     }
 
 }

--- a/src/test/java/seedu/recruittrackpro/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/recruittrackpro/logic/parser/FindCommandParserTest.java
@@ -35,7 +35,7 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"), false));
         assertParseSuccess(parser, " " + PREFIX_NAME + "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords

--- a/src/test/java/seedu/recruittrackpro/logic/parser/RecruitTrackProParserTest.java
+++ b/src/test/java/seedu/recruittrackpro/logic/parser/RecruitTrackProParserTest.java
@@ -74,7 +74,7 @@ public class RecruitTrackProParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + PREFIX_NAME + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords, false)), command);
     }
 
     @Test

--- a/src/test/java/seedu/recruittrackpro/model/ModelManagerTest.java
+++ b/src/test/java/seedu/recruittrackpro/model/ModelManagerTest.java
@@ -118,7 +118,7 @@ public class ModelManagerTest {
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getName().fullName.split("\\s+");
-        modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords), false));
         assertFalse(modelManager.equals(new ModelManager(recruitTrackPro, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests

--- a/src/test/java/seedu/recruittrackpro/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/recruittrackpro/model/person/NameContainsKeywordsPredicateTest.java
@@ -19,14 +19,17 @@ public class NameContainsKeywordsPredicateTest {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
-        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
-        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(secondPredicateKeywordList);
+        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(
+                firstPredicateKeywordList, false);
+        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(
+                secondPredicateKeywordList, false);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        NameContainsKeywordsPredicate firstPredicateCopy = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
+        NameContainsKeywordsPredicate firstPredicateCopy = new NameContainsKeywordsPredicate(
+                firstPredicateKeywordList, false);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -42,34 +45,37 @@ public class NameContainsKeywordsPredicateTest {
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(
+                Collections.singletonList("Alice"), false);
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Multiple keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"), false);
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Only one matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"), false);
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
 
         // Mixed-case keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"), false);
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(
+                Collections.emptyList(), false);
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
 
         // Non-matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"), false);
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
+        predicate = new NameContainsKeywordsPredicate(
+                Arrays.asList("12345", "alice@email.com", "Main", "Street"), false);
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
     }
@@ -77,7 +83,7 @@ public class NameContainsKeywordsPredicateTest {
     @Test
     public void toStringMethod() {
         List<String> keywords = List.of("keyword1", "keyword2");
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(keywords);
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(keywords, false);
 
         String expected = NameContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
         assertEquals(expected, predicate.toString());

--- a/src/test/java/seedu/recruittrackpro/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/recruittrackpro/model/person/NameContainsKeywordsPredicateTest.java
@@ -71,7 +71,7 @@ public class NameContainsKeywordsPredicateTest {
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Multiple keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"), false);
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"), true);
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Mixed-case keywords

--- a/src/test/java/seedu/recruittrackpro/model/person/NameContainsKeywordsPredicateTest.java
+++ b/src/test/java/seedu/recruittrackpro/model/person/NameContainsKeywordsPredicateTest.java
@@ -2,6 +2,7 @@ package seedu.recruittrackpro.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Arrays;
@@ -63,6 +64,22 @@ public class NameContainsKeywordsPredicateTest {
     }
 
     @Test
+    public void test_nameContainsAllKeywords_returnsTrue() {
+        // One keyword
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(
+                Collections.singletonList("Alice"), true);
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Multiple keywords
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"), false);
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Mixed-case keywords
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"), true);
+        assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+    }
+
+    @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
         NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(
@@ -81,11 +98,44 @@ public class NameContainsKeywordsPredicateTest {
     }
 
     @Test
+    public void test_nameDoesNotContainAllKeywords_returnsFalse() {
+        // Zero keywords
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(
+                Collections.emptyList(), true);
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
+
+        // Non-matching keyword
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"), true);
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
+
+        // Only one matching keyword
+        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"), true);
+        assertFalse(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
+    }
+
+    @Test
     public void toStringMethod() {
         List<String> keywords = List.of("keyword1", "keyword2");
         NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(keywords, false);
 
-        String expected = NameContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords + "}";
+        String expected = NameContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords
+                + ", shouldContainAll=false}";
         assertEquals(expected, predicate.toString());
+
+        predicate = new NameContainsKeywordsPredicate(keywords, true);
+
+        expected = NameContainsKeywordsPredicate.class.getCanonicalName() + "{keywords=" + keywords
+                + ", shouldContainAll=true}";
+        assertEquals(expected, predicate.toString());
+    }
+
+    @Test
+    public void equalsMethod() {
+        List<String> keywords = List.of("keyword1", "keyword2");
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(keywords, false);
+        NameContainsKeywordsPredicate containsAllPredicate = new NameContainsKeywordsPredicate(
+                keywords, true);
+
+        assertNotEquals(predicate, containsAllPredicate);
     }
 }


### PR DESCRIPTION
Fixes #71 

I decided to implement contains all instead of exact match. This means that the field must contain all keywords, irrespective of order (i.e. `find --contain-all n/alex yu` will return the same result as `find --contain-all n/yu alex`). I felt that exact match might not be that useful when we chain more fields (in the future). 

## Without `--contain-all`
![image](https://github.com/user-attachments/assets/272c8771-8cb8-4f56-a131-cc126f51e7a9)

## With `--contain-all`
![image](https://github.com/user-attachments/assets/96765f22-aa9c-41bf-92b4-80a108df7ac0)
