### PR TITLE
Add support for free-form notes

### DIFF
--- a/src/main/java/seedu/recruittrackpro/logic/Messages.java
+++ b/src/main/java/seedu/recruittrackpro/logic/Messages.java
@@ -45,6 +45,7 @@ public class Messages {
                 .append(person.getAddress())
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
+        builder.append("; Comment: ").append(person.getComment());
         return builder.toString();
     }
 

--- a/src/main/java/seedu/recruittrackpro/logic/Messages.java
+++ b/src/main/java/seedu/recruittrackpro/logic/Messages.java
@@ -43,9 +43,10 @@ public class Messages {
                 .append(person.getEmail())
                 .append("; Address: ")
                 .append(person.getAddress())
+                .append("; Comments: ")
+                .append(person.getComment())
                 .append("; Tags: ");
         person.getTags().forEach(builder::append);
-        builder.append("; Comment: ").append(person.getComment());
         return builder.toString();
     }
 

--- a/src/main/java/seedu/recruittrackpro/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/recruittrackpro/logic/commands/AddCommand.java
@@ -2,6 +2,7 @@ package seedu.recruittrackpro.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -26,14 +27,16 @@ public class AddCommand extends Command {
             + PREFIX_PHONE + "PHONE "
             + PREFIX_EMAIL + "EMAIL "
             + PREFIX_ADDRESS + "ADDRESS "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]... "
+            + "[" + PREFIX_COMMENT + "COMMENT]\n"
             + "Example: " + COMMAND_WORD + " "
             + PREFIX_NAME + "John Doe "
             + PREFIX_PHONE + "98765432 "
             + PREFIX_EMAIL + "johnd@example.com "
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_TAG + "owesMoney "
+            + PREFIX_COMMENT + "owes 5 dollars";
 
     public static final String MESSAGE_SUCCESS = "New person added: %1$s";
     public static final String MESSAGE_DUPLICATE_PERSON = "This person already exists in the address book";

--- a/src/main/java/seedu/recruittrackpro/logic/commands/AddTagsCommand.java
+++ b/src/main/java/seedu/recruittrackpro/logic/commands/AddTagsCommand.java
@@ -75,7 +75,7 @@ public class AddTagsCommand extends Command {
     private Person createUpdatedPerson(Person targetPerson, Set<Tag> newlyAddedTags, Set<Tag> currentTags) {
         currentTags.addAll(newlyAddedTags);
         return new Person(targetPerson.getName(), targetPerson.getPhone(),
-                targetPerson.getEmail(), targetPerson.getAddress(), currentTags);
+                targetPerson.getEmail(), targetPerson.getAddress(), currentTags, targetPerson.getComment());
     }
 
     /**

--- a/src/main/java/seedu/recruittrackpro/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/recruittrackpro/logic/commands/EditCommand.java
@@ -2,6 +2,7 @@ package seedu.recruittrackpro.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -22,6 +23,7 @@ import seedu.recruittrackpro.logic.Messages;
 import seedu.recruittrackpro.logic.commands.exceptions.CommandException;
 import seedu.recruittrackpro.model.Model;
 import seedu.recruittrackpro.model.person.Address;
+import seedu.recruittrackpro.model.person.Comment;
 import seedu.recruittrackpro.model.person.Email;
 import seedu.recruittrackpro.model.person.Name;
 import seedu.recruittrackpro.model.person.Person;
@@ -43,7 +45,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_PHONE + "PHONE] "
             + "[" + PREFIX_EMAIL + "EMAIL] "
             + "[" + PREFIX_ADDRESS + "ADDRESS] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]... "
+            + "[" + PREFIX_COMMENT + "COMMENT]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_PHONE + "91234567 "
             + PREFIX_EMAIL + "johndoe@example.com";
@@ -100,8 +103,9 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
+        Comment updatedComment = editPersonDescriptor.getComment().orElse(personToEdit.getComment());
 
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedComment);
     }
 
     @Override
@@ -138,6 +142,7 @@ public class EditCommand extends Command {
         private Email email;
         private Address address;
         private Set<Tag> tags;
+        private Comment comment;
 
         public EditPersonDescriptor() {}
 
@@ -151,13 +156,14 @@ public class EditCommand extends Command {
             setEmail(toCopy.email);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
+            setComment(toCopy.comment);
         }
 
         /**
          * Returns true if at least one field is edited.
          */
         public boolean isAnyFieldEdited() {
-            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags);
+            return CollectionUtil.isAnyNonNull(name, phone, email, address, tags, comment);
         }
 
         public void setName(Name name) {
@@ -209,6 +215,14 @@ public class EditCommand extends Command {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
         }
 
+        public void setComment(Comment comment) {
+            this.comment = comment;
+        }
+
+        public Optional<Comment> getComment() {
+            return Optional.ofNullable(comment);
+        }
+
         @Override
         public boolean equals(Object other) {
             if (other == this) {
@@ -225,7 +239,8 @@ public class EditCommand extends Command {
                     && Objects.equals(phone, otherEditPersonDescriptor.phone)
                     && Objects.equals(email, otherEditPersonDescriptor.email)
                     && Objects.equals(address, otherEditPersonDescriptor.address)
-                    && Objects.equals(tags, otherEditPersonDescriptor.tags);
+                    && Objects.equals(tags, otherEditPersonDescriptor.tags)
+                    && Objects.equals(comment, otherEditPersonDescriptor.comment);
         }
 
         @Override
@@ -236,6 +251,7 @@ public class EditCommand extends Command {
                     .add("email", email)
                     .add("address", address)
                     .add("tags", tags)
+                    .add("comment", comment)
                     .toString();
         }
     }

--- a/src/main/java/seedu/recruittrackpro/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/recruittrackpro/logic/parser/AddCommandParser.java
@@ -46,7 +46,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        Comment comment = ParserUtil.parseComment(argMultimap.getValue(PREFIX_COMMENT).get());
+        Comment comment = ParserUtil.parseComment(argMultimap.getValue(PREFIX_COMMENT).orElseGet(() -> ""));
 
         Person person = new Person(name, phone, email, address, tagList, comment);
 

--- a/src/main/java/seedu/recruittrackpro/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/recruittrackpro/logic/parser/AddCommandParser.java
@@ -2,6 +2,7 @@ package seedu.recruittrackpro.logic.parser;
 
 import static seedu.recruittrackpro.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -13,6 +14,7 @@ import java.util.stream.Stream;
 import seedu.recruittrackpro.logic.commands.AddCommand;
 import seedu.recruittrackpro.logic.parser.exceptions.ParseException;
 import seedu.recruittrackpro.model.person.Address;
+import seedu.recruittrackpro.model.person.Comment;
 import seedu.recruittrackpro.model.person.Email;
 import seedu.recruittrackpro.model.person.Name;
 import seedu.recruittrackpro.model.person.Person;
@@ -30,8 +32,8 @@ public class AddCommandParser implements Parser<AddCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_COMMENT);
 
         if (!arePrefixesPresent(argMultimap, PREFIX_NAME, PREFIX_ADDRESS, PREFIX_PHONE, PREFIX_EMAIL)
                 || !argMultimap.getPreamble().isEmpty()) {
@@ -44,8 +46,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        Comment comment = ParserUtil.parseComment(argMultimap.getValue(PREFIX_COMMENT).get());
 
-        Person person = new Person(name, phone, email, address, tagList);
+        Person person = new Person(name, phone, email, address, tagList, comment);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/recruittrackpro/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/recruittrackpro/logic/parser/CliSyntax.java
@@ -11,5 +11,6 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_COMMENT = new Prefix("c/");
 
 }

--- a/src/main/java/seedu/recruittrackpro/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/recruittrackpro/logic/parser/EditCommandParser.java
@@ -3,6 +3,7 @@ package seedu.recruittrackpro.logic.parser;
 import static java.util.Objects.requireNonNull;
 import static seedu.recruittrackpro.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -31,8 +32,8 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(
+                args, PREFIX_NAME, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG, PREFIX_COMMENT);
 
         Index index;
 
@@ -59,6 +60,9 @@ public class EditCommandParser implements Parser<EditCommand> {
             editPersonDescriptor.setAddress(ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get()));
         }
         parseTagsForEdit(argMultimap.getAllValues(PREFIX_TAG)).ifPresent(editPersonDescriptor::setTags);
+        if (argMultimap.getValue(PREFIX_COMMENT).isPresent()) {
+            editPersonDescriptor.setComment(ParserUtil.parseComment(argMultimap.getValue(PREFIX_COMMENT).get()));
+        }
 
         if (!editPersonDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);

--- a/src/main/java/seedu/recruittrackpro/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/recruittrackpro/logic/parser/ParserUtil.java
@@ -10,6 +10,7 @@ import seedu.recruittrackpro.commons.core.index.Index;
 import seedu.recruittrackpro.commons.util.StringUtil;
 import seedu.recruittrackpro.logic.parser.exceptions.ParseException;
 import seedu.recruittrackpro.model.person.Address;
+import seedu.recruittrackpro.model.person.Comment;
 import seedu.recruittrackpro.model.person.Email;
 import seedu.recruittrackpro.model.person.Name;
 import seedu.recruittrackpro.model.person.Phone;
@@ -120,5 +121,20 @@ public class ParserUtil {
             tagSet.add(parseTag(tagName));
         }
         return tagSet;
+    }
+
+    /**
+     * Parses a {@code String comment} into a {@code Comment}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code comment} is invalid.
+     */
+    public static Comment parseComment(String comment) throws ParseException {
+        requireNonNull(comment);
+        String trimmedComment = comment.trim();
+        if (!Comment.isValidComment(trimmedComment)) {
+            throw new ParseException(Comment.MESSAGE_CONSTRAINTS);
+        }
+        return new Comment(trimmedComment);
     }
 }

--- a/src/main/java/seedu/recruittrackpro/model/person/Comment.java
+++ b/src/main/java/seedu/recruittrackpro/model/person/Comment.java
@@ -1,0 +1,59 @@
+package seedu.recruittrackpro.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.recruittrackpro.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a Person's comment in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidComment(String)}
+ */
+public class Comment {
+    public static final String MESSAGE_CONSTRAINTS = "Comments should not exceed 500 characters";
+
+    public static final String VALIDATION_REGEX = ".{0,500}";
+
+    public final String value;
+
+    /**
+     * Constructs a {@code Comment}.
+     *
+     * @param comment A valid comment.
+     */
+    public Comment(String comment) {
+        requireNonNull(comment);
+        checkArgument(isValidComment(comment), MESSAGE_CONSTRAINTS);
+        this.value = comment;
+    }
+
+    /**
+     * Returns true if a given string is a valid name.
+     */
+    public static boolean isValidComment(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+    @Override
+    public String toString() {
+        return value;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof Comment)) {
+            return false;
+        }
+
+        Comment otherComment = (Comment) other;
+        return value.equals(otherComment.value);
+    }
+
+    @Override
+    public int hashCode() {
+        return value.hashCode();
+    }
+}

--- a/src/main/java/seedu/recruittrackpro/model/person/Comment.java
+++ b/src/main/java/seedu/recruittrackpro/model/person/Comment.java
@@ -26,7 +26,7 @@ public class Comment {
     }
 
     /**
-     * Returns true if a given string is a valid name.
+     * Returns true if a given string is a valid comment.
      */
     public static boolean isValidComment(String test) {
         return test.matches(VALIDATION_REGEX);

--- a/src/main/java/seedu/recruittrackpro/model/person/Person.java
+++ b/src/main/java/seedu/recruittrackpro/model/person/Person.java
@@ -24,17 +24,19 @@ public class Person {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+    private final Comment comment;
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, tags);
+    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags, Comment comment) {
+        requireAllNonNull(name, phone, email, address, tags, comment);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+        this.comment = comment;
     }
 
     public Name getName() {
@@ -59,6 +61,10 @@ public class Person {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    public Comment getComment() {
+        return comment;
     }
 
     /**
@@ -94,13 +100,14 @@ public class Person {
                 && phone.equals(otherPerson.phone)
                 && email.equals(otherPerson.email)
                 && address.equals(otherPerson.address)
-                && tags.equals(otherPerson.tags);
+                && tags.equals(otherPerson.tags)
+                && comment.equals(otherPerson.comment);
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, tags, comment);
     }
 
     @Override
@@ -111,6 +118,7 @@ public class Person {
                 .add("email", email)
                 .add("address", address)
                 .add("tags", tags)
+                .add("comment", comment)
                 .toString();
     }
 

--- a/src/main/java/seedu/recruittrackpro/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/recruittrackpro/model/util/SampleDataUtil.java
@@ -22,7 +22,7 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends"), new Comment("")),
+                getTagSet("friends"), new Comment("Do not disturb")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
                 getTagSet("colleagues", "friends"), new Comment("")),
@@ -34,10 +34,10 @@ public class SampleDataUtil {
                 getTagSet("family"), new Comment("")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates"), new Comment("")),
+                getTagSet("classmates"), new Comment("Do not disturb")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"), new Comment(""))
+                getTagSet("colleagues"), new Comment("Do not disturb"))
         };
     }
 

--- a/src/main/java/seedu/recruittrackpro/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/recruittrackpro/model/util/SampleDataUtil.java
@@ -22,22 +22,28 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends"), new Comment("Do not disturb")),
+                getTagSet("friends"),
+                new Comment("Do not disturb")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends"), new Comment("")),
+                getTagSet("colleagues", "friends"),
+                new Comment("")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours"), new Comment("")),
+                getTagSet("neighbours"),
+                new Comment("")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family"), new Comment("")),
+                getTagSet("family"),
+                new Comment("")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates"), new Comment("Do not disturb")),
+                getTagSet("classmates"),
+                new Comment("Do not disturb")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"), new Comment("Do not disturb"))
+                getTagSet("colleagues"),
+                new Comment("Do not disturb"))
         };
     }
 

--- a/src/main/java/seedu/recruittrackpro/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/recruittrackpro/model/util/SampleDataUtil.java
@@ -7,6 +7,7 @@ import java.util.stream.Collectors;
 import seedu.recruittrackpro.model.ReadOnlyRecruitTrackPro;
 import seedu.recruittrackpro.model.RecruitTrackPro;
 import seedu.recruittrackpro.model.person.Address;
+import seedu.recruittrackpro.model.person.Comment;
 import seedu.recruittrackpro.model.person.Email;
 import seedu.recruittrackpro.model.person.Name;
 import seedu.recruittrackpro.model.person.Person;
@@ -21,22 +22,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends")),
+                getTagSet("friends"), new Comment("")),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends")),
+                getTagSet("colleagues", "friends"), new Comment("")),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours")),
+                getTagSet("neighbours"), new Comment("")),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family")),
+                getTagSet("family"), new Comment("")),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates")),
+                getTagSet("classmates"), new Comment("")),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"))
+                getTagSet("colleagues"), new Comment(""))
         };
     }
 

--- a/src/main/java/seedu/recruittrackpro/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/recruittrackpro/storage/JsonAdaptedPerson.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.recruittrackpro.commons.exceptions.IllegalValueException;
 import seedu.recruittrackpro.model.person.Address;
+import seedu.recruittrackpro.model.person.Comment;
 import seedu.recruittrackpro.model.person.Email;
 import seedu.recruittrackpro.model.person.Name;
 import seedu.recruittrackpro.model.person.Person;
@@ -29,6 +30,7 @@ class JsonAdaptedPerson {
     private final String email;
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
+    private final String comment;
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -36,7 +38,7 @@ class JsonAdaptedPerson {
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tags") List<JsonAdaptedTag> tags) {
+            @JsonProperty("tags") List<JsonAdaptedTag> tags, @JsonProperty("comment") String comment) {
         this.name = name;
         this.phone = phone;
         this.email = email;
@@ -44,6 +46,7 @@ class JsonAdaptedPerson {
         if (tags != null) {
             this.tags.addAll(tags);
         }
+        this.comment = comment;
     }
 
     /**
@@ -57,6 +60,7 @@ class JsonAdaptedPerson {
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        comment = source.getComment().value;
     }
 
     /**
@@ -103,7 +107,16 @@ class JsonAdaptedPerson {
         final Address modelAddress = new Address(address);
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+
+        if (comment == null) {
+            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Comment.class.getSimpleName()));
+        }
+        if (!Comment.isValidComment(comment)) {
+            throw new IllegalValueException(Comment.MESSAGE_CONSTRAINTS);
+        }
+        final Comment modelComment = new Comment(comment);
+
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags, modelComment);
     }
 
 }

--- a/src/main/java/seedu/recruittrackpro/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/recruittrackpro/storage/JsonAdaptedPerson.java
@@ -30,7 +30,7 @@ class JsonAdaptedPerson {
     private final String email;
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
-    private final String comment;
+    private String comment = "";
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
@@ -46,7 +46,9 @@ class JsonAdaptedPerson {
         if (tags != null) {
             this.tags.addAll(tags);
         }
-        this.comment = comment;
+        if (comment != null) {
+            this.comment = comment;
+        }
     }
 
     /**
@@ -108,9 +110,6 @@ class JsonAdaptedPerson {
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
-        if (comment == null) {
-            throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Comment.class.getSimpleName()));
-        }
         if (!Comment.isValidComment(comment)) {
             throw new IllegalValueException(Comment.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/recruittrackpro/ui/PersonCard.java
+++ b/src/main/java/seedu/recruittrackpro/ui/PersonCard.java
@@ -40,6 +40,8 @@ public class PersonCard extends UiPart<Region> {
     private Label email;
     @FXML
     private FlowPane tags;
+    @FXML
+    private Label comment;
 
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
@@ -55,5 +57,6 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+        comment.setText(person.getComment().value);
     }
 }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -37,7 +37,7 @@
           </VBox>
           <Separator orientation="VERTICAL" GridPane.columnIndex="1" />
           <VBox GridPane.columnIndex="2">
-            <Label styleClass="cell_medium_label">Notes:</Label>
+            <Label styleClass="cell_medium_label">Comments:</Label>
             <Label fx:id="comment" styleClass="cell_small_label" text="\$comment" wrapText="true" />
           </VBox>
         </children>

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -38,6 +38,7 @@
           <Separator orientation="VERTICAL" GridPane.columnIndex="1" />
           <VBox GridPane.columnIndex="2">
             <Label styleClass="cell_medium_label">Notes:</Label>
+            <Label fx:id="comment" styleClass="cell_small_label" text="\$comment" wrapText="true" />
           </VBox>
         </children>
         <columnConstraints>

--- a/src/test/java/seedu/recruittrackpro/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/recruittrackpro/logic/commands/CommandTestUtil.java
@@ -3,6 +3,7 @@ package seedu.recruittrackpro.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -47,6 +48,7 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String COMMENT_DESC_EMPTY = " " + PREFIX_COMMENT;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones

--- a/src/test/java/seedu/recruittrackpro/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/recruittrackpro/logic/commands/CommandTestUtil.java
@@ -37,6 +37,7 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_COMMENT_DND = "do not disturb";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -48,13 +49,14 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
-    public static final String COMMENT_DESC_EMPTY = " " + PREFIX_COMMENT;
+    public static final String COMMENT_DESC_DND = " " + PREFIX_COMMENT + VALID_COMMENT_DND;
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*12345678901234567890"; // too long
+    public static final String INVALID_COMMENT_DESC = " " + PREFIX_COMMENT + "A".repeat(501); // too long
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/recruittrackpro/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/recruittrackpro/logic/commands/EditPersonDescriptorTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.DESC_AMY;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.DESC_BOB;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_COMMENT_DND;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
@@ -54,6 +55,10 @@ public class EditPersonDescriptorTest {
 
         // different tags -> returns false
         editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withTags(VALID_TAG_HUSBAND).build();
+        assertFalse(DESC_AMY.equals(editedAmy));
+
+        // different comment -> returns false
+        editedAmy = new EditPersonDescriptorBuilder(DESC_AMY).withComment(VALID_COMMENT_DND).build();
         assertFalse(DESC_AMY.equals(editedAmy));
     }
 

--- a/src/test/java/seedu/recruittrackpro/logic/commands/EditPersonDescriptorTest.java
+++ b/src/test/java/seedu/recruittrackpro/logic/commands/EditPersonDescriptorTest.java
@@ -65,7 +65,8 @@ public class EditPersonDescriptorTest {
                 + editPersonDescriptor.getPhone().orElse(null) + ", email="
                 + editPersonDescriptor.getEmail().orElse(null) + ", address="
                 + editPersonDescriptor.getAddress().orElse(null) + ", tags="
-                + editPersonDescriptor.getTags().orElse(null) + "}";
+                + editPersonDescriptor.getTags().orElse(null) + ", comment="
+                + editPersonDescriptor.getComment().orElse(null) + "}";
         assertEquals(expected, editPersonDescriptor.toString());
     }
 }

--- a/src/test/java/seedu/recruittrackpro/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/recruittrackpro/logic/parser/AddCommandParserTest.java
@@ -3,6 +3,7 @@ package seedu.recruittrackpro.logic.parser;
 import static seedu.recruittrackpro.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.recruittrackpro.logic.commands.CommandTestUtil.COMMENT_DESC_EMPTY;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
@@ -54,7 +55,7 @@ public class AddCommandParserTest {
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND, new AddCommand(expectedPerson));
+                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + COMMENT_DESC_EMPTY, new AddCommand(expectedPerson));
 
 
         // multiple tags - all accepted

--- a/src/test/java/seedu/recruittrackpro/logic/parser/AddCommandParserTest.java
+++ b/src/test/java/seedu/recruittrackpro/logic/parser/AddCommandParserTest.java
@@ -3,7 +3,7 @@ package seedu.recruittrackpro.logic.parser;
 import static seedu.recruittrackpro.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
-import static seedu.recruittrackpro.logic.commands.CommandTestUtil.COMMENT_DESC_EMPTY;
+import static seedu.recruittrackpro.logic.commands.CommandTestUtil.COMMENT_DESC_DND;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
@@ -20,6 +20,7 @@ import static seedu.recruittrackpro.logic.commands.CommandTestUtil.PREAMBLE_WHIT
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_COMMENT_DND;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
@@ -51,11 +52,12 @@ public class AddCommandParserTest {
 
     @Test
     public void parse_allFieldsPresent_success() {
-        Person expectedPerson = new PersonBuilder(BOB).withTags(VALID_TAG_FRIEND).build();
+        Person expectedPerson = new PersonBuilder(BOB)
+                .withTags(VALID_TAG_FRIEND).withComment(VALID_COMMENT_DND).build();
 
         // whitespace only preamble
         assertParseSuccess(parser, PREAMBLE_WHITESPACE + NAME_DESC_BOB + PHONE_DESC_BOB + EMAIL_DESC_BOB
-                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + COMMENT_DESC_EMPTY, new AddCommand(expectedPerson));
+                + ADDRESS_DESC_BOB + TAG_DESC_FRIEND + COMMENT_DESC_DND, new AddCommand(expectedPerson));
 
 
         // multiple tags - all accepted

--- a/src/test/java/seedu/recruittrackpro/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/recruittrackpro/logic/parser/EditCommandParserTest.java
@@ -3,9 +3,11 @@ package seedu.recruittrackpro.logic.parser;
 import static seedu.recruittrackpro.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.ADDRESS_DESC_BOB;
+import static seedu.recruittrackpro.logic.commands.CommandTestUtil.COMMENT_DESC_DND;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.EMAIL_DESC_BOB;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.INVALID_ADDRESS_DESC;
+import static seedu.recruittrackpro.logic.commands.CommandTestUtil.INVALID_COMMENT_DESC;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.INVALID_EMAIL_DESC;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.INVALID_PHONE_DESC;
@@ -16,6 +18,7 @@ import static seedu.recruittrackpro.logic.commands.CommandTestUtil.PHONE_DESC_BO
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.TAG_DESC_FRIEND;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.TAG_DESC_HUSBAND;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_ADDRESS_AMY;
+import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_COMMENT_DND;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_EMAIL_AMY;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_NAME_AMY;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_PHONE_AMY;
@@ -39,6 +42,7 @@ import seedu.recruittrackpro.logic.Messages;
 import seedu.recruittrackpro.logic.commands.EditCommand;
 import seedu.recruittrackpro.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.recruittrackpro.model.person.Address;
+import seedu.recruittrackpro.model.person.Comment;
 import seedu.recruittrackpro.model.person.Email;
 import seedu.recruittrackpro.model.person.Name;
 import seedu.recruittrackpro.model.person.Phone;
@@ -88,6 +92,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
         assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
+        assertParseFailure(parser, "1" + INVALID_COMMENT_DESC, Comment.MESSAGE_CONSTRAINTS); // invalid tag
 
         // invalid phone followed by valid email
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);
@@ -107,11 +112,11 @@ public class EditCommandParserTest {
     public void parse_allFieldsSpecified_success() {
         Index targetIndex = INDEX_SECOND_PERSON;
         String userInput = targetIndex.getOneBased() + PHONE_DESC_BOB + TAG_DESC_HUSBAND
-                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND;
+                + EMAIL_DESC_AMY + ADDRESS_DESC_AMY + NAME_DESC_AMY + TAG_DESC_FRIEND + COMMENT_DESC_DND;
 
         EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder().withName(VALID_NAME_AMY)
                 .withPhone(VALID_PHONE_BOB).withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY)
-                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).build();
+                .withTags(VALID_TAG_HUSBAND, VALID_TAG_FRIEND).withComment(VALID_COMMENT_DND).build();
         EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
 
         assertParseSuccess(parser, userInput, expectedCommand);
@@ -159,6 +164,12 @@ public class EditCommandParserTest {
         // tags
         userInput = targetIndex.getOneBased() + TAG_DESC_FRIEND;
         descriptor = new EditPersonDescriptorBuilder().withTags(VALID_TAG_FRIEND).build();
+        expectedCommand = new EditCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        // comment
+        userInput = targetIndex.getOneBased() + COMMENT_DESC_DND;
+        descriptor = new EditPersonDescriptorBuilder().withComment(VALID_COMMENT_DND).build();
         expectedCommand = new EditCommand(targetIndex, descriptor);
         assertParseSuccess(parser, userInput, expectedCommand);
     }

--- a/src/test/java/seedu/recruittrackpro/logic/parser/EditCommandParserTest.java
+++ b/src/test/java/seedu/recruittrackpro/logic/parser/EditCommandParserTest.java
@@ -92,7 +92,7 @@ public class EditCommandParserTest {
         assertParseFailure(parser, "1" + INVALID_EMAIL_DESC, Email.MESSAGE_CONSTRAINTS); // invalid email
         assertParseFailure(parser, "1" + INVALID_ADDRESS_DESC, Address.MESSAGE_CONSTRAINTS); // invalid address
         assertParseFailure(parser, "1" + INVALID_TAG_DESC, Tag.MESSAGE_CONSTRAINTS); // invalid tag
-        assertParseFailure(parser, "1" + INVALID_COMMENT_DESC, Comment.MESSAGE_CONSTRAINTS); // invalid tag
+        assertParseFailure(parser, "1" + INVALID_COMMENT_DESC, Comment.MESSAGE_CONSTRAINTS); // invalid comment
 
         // invalid phone followed by valid email
         assertParseFailure(parser, "1" + INVALID_PHONE_DESC + EMAIL_DESC_AMY, Phone.MESSAGE_CONSTRAINTS);

--- a/src/test/java/seedu/recruittrackpro/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/recruittrackpro/logic/parser/ParserUtilTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.recruittrackpro.logic.parser.exceptions.ParseException;
 import seedu.recruittrackpro.model.person.Address;
+import seedu.recruittrackpro.model.person.Comment;
 import seedu.recruittrackpro.model.person.Email;
 import seedu.recruittrackpro.model.person.Name;
 import seedu.recruittrackpro.model.person.Phone;
@@ -26,6 +27,7 @@ public class ParserUtilTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = " ";
+    private static final String INVALID_COMMENT = "A".repeat(501);
 
     private static final String VALID_NAME = "Rachel Walker";
     private static final String VALID_PHONE = "123456";
@@ -33,6 +35,7 @@ public class ParserUtilTest {
     private static final String VALID_EMAIL = "rachel@example.com";
     private static final String VALID_TAG_1 = "friend";
     private static final String VALID_TAG_2 = "neighbour";
+    private static final String VALID_COMMENT = "do not disturb";
 
     private static final String WHITESPACE = " \t\r\n";
 
@@ -192,5 +195,28 @@ public class ParserUtilTest {
         Set<Tag> expectedTagSet = new HashSet<Tag>(Arrays.asList(new Tag(VALID_TAG_1), new Tag(VALID_TAG_2)));
 
         assertEquals(expectedTagSet, actualTagSet);
+    }
+
+    @Test
+    public void parseComment_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> ParserUtil.parseComment((String) null));
+    }
+
+    @Test
+    public void parseComment_invalidValue_throwsParseException() {
+        assertThrows(ParseException.class, () -> ParserUtil.parseComment(INVALID_COMMENT));
+    }
+
+    @Test
+    public void parseComment_validValueWithoutWhitespace_returnsComment() throws Exception {
+        Comment expectedComment = new Comment(VALID_COMMENT);
+        assertEquals(expectedComment, ParserUtil.parseComment(VALID_COMMENT));
+    }
+
+    @Test
+    public void parseComment_validValueWithWhitespace_returnsTrimmedComment() throws Exception {
+        String commentWithWhitespace = WHITESPACE + VALID_COMMENT + WHITESPACE;
+        Comment expectedComment = new Comment(VALID_COMMENT);
+        assertEquals(expectedComment, ParserUtil.parseComment(commentWithWhitespace));
     }
 }

--- a/src/test/java/seedu/recruittrackpro/model/person/CommentTest.java
+++ b/src/test/java/seedu/recruittrackpro/model/person/CommentTest.java
@@ -1,0 +1,53 @@
+package seedu.recruittrackpro.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.recruittrackpro.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class CommentTest {
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Comment(null));
+    }
+
+    @Test
+    public void constructor_invalidComment_throwsIllegalArgumentException() {
+        String invalidComment = "A".repeat(501);
+        assertThrows(IllegalArgumentException.class, () -> new Comment(invalidComment));
+    }
+
+    @Test
+    public void isValidComment() {
+        // null comment
+        assertThrows(NullPointerException.class, () -> Comment.isValidComment(null));
+
+        // invalid comment
+        assertFalse(Comment.isValidComment("A".repeat(501))); // too long
+
+        // valid comments
+        assertTrue(Comment.isValidComment("do not disturb"));
+        assertTrue(Comment.isValidComment("")); // blank
+    }
+
+    @Test
+    public void equals() {
+        Comment comment = new Comment("Valid Comment");
+
+        // same values -> returns true
+        assertTrue(comment.equals(new Comment("Valid Comment")));
+
+        // same object -> returns true
+        assertTrue(comment.equals(comment));
+
+        // null -> returns false
+        assertFalse(comment.equals(null));
+
+        // different types -> returns false
+        assertFalse(comment.equals(5.0f));
+
+        // different values -> returns false
+        assertFalse(comment.equals(new Comment("Other Valid Comment")));
+    }
+}

--- a/src/test/java/seedu/recruittrackpro/model/person/PersonTest.java
+++ b/src/test/java/seedu/recruittrackpro/model/person/PersonTest.java
@@ -93,7 +93,8 @@ public class PersonTest {
     @Test
     public void toStringMethod() {
         String expected = Person.class.getCanonicalName() + "{name=" + ALICE.getName() + ", phone=" + ALICE.getPhone()
-                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags() + "}";
+                + ", email=" + ALICE.getEmail() + ", address=" + ALICE.getAddress() + ", tags=" + ALICE.getTags()
+                + ", comment=" + ALICE.getComment() + "}";
         assertEquals(expected, ALICE.toString());
     }
 }

--- a/src/test/java/seedu/recruittrackpro/model/person/PersonTest.java
+++ b/src/test/java/seedu/recruittrackpro/model/person/PersonTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_ADDRESS_BOB;
+import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_COMMENT_DND;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_EMAIL_BOB;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.recruittrackpro.logic.commands.CommandTestUtil.VALID_PHONE_BOB;
@@ -87,6 +88,10 @@ public class PersonTest {
 
         // different tags -> returns false
         editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
+        assertFalse(ALICE.equals(editedAlice));
+
+        // different comment -> returns false
+        editedAlice = new PersonBuilder(ALICE).withComment(VALID_COMMENT_DND).build();
         assertFalse(ALICE.equals(editedAlice));
     }
 

--- a/src/test/java/seedu/recruittrackpro/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/recruittrackpro/storage/JsonAdaptedPersonTest.java
@@ -31,6 +31,7 @@ public class JsonAdaptedPersonTest {
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
+    private static final String VALID_COMMENT = BENSON.getComment().toString();
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
@@ -40,60 +41,64 @@ public class JsonAdaptedPersonTest {
 
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_COMMENT);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_COMMENT);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_COMMENT);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_COMMENT);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_COMMENT);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_COMMENT);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_COMMENT);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_COMMENT);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -102,8 +107,8 @@ public class JsonAdaptedPersonTest {
     public void toModelType_invalidTags_throwsIllegalValueException() {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_COMMENT);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 

--- a/src/test/java/seedu/recruittrackpro/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/recruittrackpro/storage/JsonAdaptedPersonTest.java
@@ -13,6 +13,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.recruittrackpro.commons.exceptions.IllegalValueException;
 import seedu.recruittrackpro.model.person.Address;
+import seedu.recruittrackpro.model.person.Comment;
 import seedu.recruittrackpro.model.person.Email;
 import seedu.recruittrackpro.model.person.Name;
 import seedu.recruittrackpro.model.person.Phone;
@@ -23,6 +24,7 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_ADDRESS = " ";
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = " ";
+    private static final String INVALID_COMMENT = "A".repeat(501);
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
@@ -110,6 +112,14 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person = new JsonAdaptedPerson(
                 VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_COMMENT);
         assertThrows(IllegalValueException.class, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_invalidComment_throwsIllegalValueException() {
+        JsonAdaptedPerson person = new JsonAdaptedPerson(
+                VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, INVALID_COMMENT);
+        String expectedMessage = Comment.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
 }

--- a/src/test/java/seedu/recruittrackpro/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/recruittrackpro/testutil/EditPersonDescriptorBuilder.java
@@ -38,6 +38,7 @@ public class EditPersonDescriptorBuilder {
         descriptor.setEmail(person.getEmail());
         descriptor.setAddress(person.getAddress());
         descriptor.setTags(person.getTags());
+        descriptor.setComment(person.getComment());
     }
 
     /**

--- a/src/test/java/seedu/recruittrackpro/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/recruittrackpro/testutil/EditPersonDescriptorBuilder.java
@@ -6,6 +6,7 @@ import java.util.stream.Stream;
 
 import seedu.recruittrackpro.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.recruittrackpro.model.person.Address;
+import seedu.recruittrackpro.model.person.Comment;
 import seedu.recruittrackpro.model.person.Email;
 import seedu.recruittrackpro.model.person.Name;
 import seedu.recruittrackpro.model.person.Person;
@@ -78,6 +79,14 @@ public class EditPersonDescriptorBuilder {
     public EditPersonDescriptorBuilder withTags(String... tags) {
         Set<Tag> tagSet = Stream.of(tags).map(Tag::new).collect(Collectors.toSet());
         descriptor.setTags(tagSet);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Comment} of the {@code EditPersonDescriptor} that we are building.
+     */
+    public EditPersonDescriptorBuilder withComment(String comment) {
+        descriptor.setComment(new Comment(comment));
         return this;
     }
 

--- a/src/test/java/seedu/recruittrackpro/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/recruittrackpro/testutil/PersonBuilder.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import seedu.recruittrackpro.model.person.Address;
+import seedu.recruittrackpro.model.person.Comment;
 import seedu.recruittrackpro.model.person.Email;
 import seedu.recruittrackpro.model.person.Name;
 import seedu.recruittrackpro.model.person.Person;
@@ -20,12 +21,14 @@ public class PersonBuilder {
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
+    public static final String DEFAULT_COMMENT = "";
 
     private Name name;
     private Phone phone;
     private Email email;
     private Address address;
     private Set<Tag> tags;
+    private Comment comment;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -36,6 +39,7 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
+        comment = new Comment(DEFAULT_COMMENT);
     }
 
     /**
@@ -47,6 +51,7 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
         tags = new HashSet<>(personToCopy.getTags());
+        comment = personToCopy.getComment();
     }
 
     /**
@@ -98,8 +103,16 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Comment} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withComment(String comment) {
+        this.comment = new Comment(comment);
+        return this;
+    }
+
     public Person build() {
-        return new Person(name, phone, email, address, tags);
+        return new Person(name, phone, email, address, tags, comment);
     }
 
 }

--- a/src/test/java/seedu/recruittrackpro/testutil/PersonUtil.java
+++ b/src/test/java/seedu/recruittrackpro/testutil/PersonUtil.java
@@ -1,6 +1,7 @@
 package seedu.recruittrackpro.testutil;
 
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_COMMENT;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_EMAIL;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.recruittrackpro.logic.parser.CliSyntax.PREFIX_PHONE;
@@ -37,6 +38,7 @@ public class PersonUtil {
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
+        sb.append(PREFIX_COMMENT + person.getComment().value);
         return sb.toString();
     }
 

--- a/src/test/java/seedu/recruittrackpro/testutil/PersonUtil.java
+++ b/src/test/java/seedu/recruittrackpro/testutil/PersonUtil.java
@@ -38,7 +38,7 @@ public class PersonUtil {
         person.getTags().stream().forEach(
             s -> sb.append(PREFIX_TAG + s.tagName + " ")
         );
-        sb.append(PREFIX_COMMENT + person.getComment().value);
+        sb.append(PREFIX_COMMENT + person.getComment().value + " ");
         return sb.toString();
     }
 
@@ -54,11 +54,13 @@ public class PersonUtil {
         if (descriptor.getTags().isPresent()) {
             Set<Tag> tags = descriptor.getTags().get();
             if (tags.isEmpty()) {
-                sb.append(PREFIX_TAG);
+                sb.append(PREFIX_TAG).append(" ");
             } else {
                 tags.forEach(s -> sb.append(PREFIX_TAG).append(s.tagName).append(" "));
             }
         }
+        descriptor.getComment().ifPresent(
+                comment -> sb.append(PREFIX_COMMENT).append(comment.value).append(" "));
         return sb.toString();
     }
 }


### PR DESCRIPTION
Fixes #101 

~Pending PR #100 to be merged; will rebase after.~
Sorry for the lengthy PR, I kinda auto-piloted 😅 I will do a thorough check again after rebase.

After some thinking, I realised it does not make sense to create a new `note` command. Instead, I have integrated it into `edit` (and `add`) command.

## Sample data
![image](https://github.com/user-attachments/assets/31ec1e2c-b61c-4610-81b6-b73f090b08fd)

## Edit command
![image](https://github.com/user-attachments/assets/97bc85e5-df25-4e71-b6df-ef5c2cbc5dba)

## Add command
![image](https://github.com/user-attachments/assets/00b8d01e-6418-45c1-bd84-f62829c419ea)
