### PR TITLE
Fix GUI to not block the comments on smaller window size

### DIFF
--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -10,43 +10,38 @@
 <?import javafx.scene.layout.Region?>
 <?import javafx.scene.layout.VBox?>
 <HBox id="cardPane" fx:id="cardPane" xmlns="http://javafx.com/javafx/17" xmlns:fx="http://javafx.com/fxml/1">
-  <GridPane HBox.hgrow="ALWAYS">
-    <columnConstraints>
-      <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
-    </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
-      <padding>
-        <Insets top="5" right="5" bottom="5" left="15" />
-      </padding>
-      <HBox spacing="0.5" alignment="CENTER_LEFT">
-        <Label fx:id="id" styleClass="cell_big_label">
-          <minWidth>
-            <!-- Ensures that the label text is never truncated -->
-            <Region fx:constant="USE_PREF_SIZE" />
-          </minWidth>
-        </Label>
-        <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
-      </HBox>
-      <GridPane>
-        <children>
-          <VBox GridPane.columnIndex="0">
-            <FlowPane fx:id="tags" />
-            <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
-            <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-            <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
-          </VBox>
-          <Separator orientation="VERTICAL" GridPane.columnIndex="1" />
-          <VBox GridPane.columnIndex="2">
-            <Label styleClass="cell_medium_label">Comments:</Label>
-            <Label fx:id="comment" styleClass="cell_small_label" text="\$comment" wrapText="true" />
-          </VBox>
-        </children>
-        <columnConstraints>
-          <ColumnConstraints percentWidth="49.5" />
-          <ColumnConstraints percentWidth="1" />
-          <ColumnConstraints percentWidth="49.5" />
-        </columnConstraints>
-      </GridPane>
-    </VBox>
-  </GridPane>
+  <VBox HBox.hgrow="SOMETIMES" prefWidth="150">
+    <padding>
+      <Insets top="5" right="15" bottom="5" left="15" />
+    </padding>
+    <HBox spacing="0.5" alignment="CENTER_LEFT">
+      <Label fx:id="id" styleClass="cell_big_label">
+        <minWidth>
+          <!-- Ensures that the label text is never truncated -->
+          <Region fx:constant="USE_PREF_SIZE" />
+        </minWidth>
+      </Label>
+      <Label fx:id="name" text="\$first" styleClass="cell_big_label" />
+    </HBox>
+    <GridPane>
+      <columnConstraints>
+        <ColumnConstraints percentWidth="49.5" />
+        <ColumnConstraints percentWidth="1" />
+        <ColumnConstraints percentWidth="49.5" />
+      </columnConstraints>
+      <children>
+        <VBox GridPane.columnIndex="0">
+          <FlowPane fx:id="tags" />
+          <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
+          <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
+          <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+        </VBox>
+        <Separator orientation="VERTICAL" GridPane.columnIndex="1" />
+        <VBox GridPane.columnIndex="2">
+          <Label styleClass="cell_medium_label">Comments:</Label>
+          <Label fx:id="comment" styleClass="cell_small_label" text="\$comment" wrapText="true" />
+        </VBox>
+      </children>
+    </GridPane>
+  </VBox>
 </HBox>


### PR DESCRIPTION
Fixes #112 

A minimal fix to allow horizontal scrolling on smaller window size. Can be improved in later iterations (if needed).

![image](https://github.com/user-attachments/assets/be771e0d-9237-400e-978e-ec6caf122259)