### PR TITLE
Add support for command history

### DIFF
--- a/src/main/java/seedu/recruittrackpro/ui/CommandBox.java
+++ b/src/main/java/seedu/recruittrackpro/ui/CommandBox.java
@@ -171,7 +171,7 @@ public class CommandBox extends UiPart<Region> {
     }
 
     /**
-     * Represents a string representation of a command that was previously executed.
+     * Represents a {@code String} that conforms to a command previously executed.
      */
     private static class ExecutedCommand {
 

--- a/src/main/java/seedu/recruittrackpro/ui/CommandBox.java
+++ b/src/main/java/seedu/recruittrackpro/ui/CommandBox.java
@@ -21,7 +21,7 @@ public class CommandBox extends UiPart<Region> {
 
     private final CommandExecutor commandExecutor;
     private final LinkedList<ExecutedCommand> history = new LinkedList<>();
-    private ExecutedCommand referencedCommand;
+    private ExecutedCommand referenceCommand;
 
     @FXML
     private TextField commandTextField;
@@ -50,7 +50,7 @@ public class CommandBox extends UiPart<Region> {
         try {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
-            referencedCommand = null;
+            referenceCommand = null;
 
             ExecutedCommand commandEntered = new ExecutedCommand(commandText);
             if (!history.isEmpty()) {
@@ -64,43 +64,56 @@ public class CommandBox extends UiPart<Region> {
         }
     }
 
-    @FXML
+    private void handleUpKey() {
+        if (referenceCommand == null) {
+            referenceCommand = history.getLast();
+            commandTextField.setText(referenceCommand.getValue());
+            return;
+        }
+
+        ExecutedCommand previous = referenceCommand.getPrevious();
+        if (previous == null) {
+            return;
+        }
+
+        referenceCommand = previous;
+        commandTextField.setText(referenceCommand.getValue());
+    }
+
+    private void handleDownKey() {
+        if (referenceCommand == null) {
+            return;
+        }
+
+        ExecutedCommand next = referenceCommand.getNext();
+        if (next == null) {
+            commandTextField.setText("");
+            referenceCommand = null;
+            return;
+        }
+
+        referenceCommand = next;
+        commandTextField.setText(referenceCommand.getValue());
+    }
+
     private void handleKeyPressed(KeyEvent event) {
         String keyPressed = event.getCode().toString();
-        if ((!keyPressed.equals("UP") && !keyPressed.equals("DOWN")) || history.isEmpty()) {
+        if ((!keyPressed.equals("UP") && !keyPressed.equals("DOWN"))) {
             return;
         }
+        event.consume(); // to override default behaviour
 
-        if (keyPressed.equals("UP") && referencedCommand == null) {
-            referencedCommand = history.getLast();
-            commandTextField.setText(referencedCommand.getValue());
-            return;
-        }
-
-        if (keyPressed.equals("DOWN") && referencedCommand == null) {
-            return;
-        }
-
-        ExecutedCommand previous = referencedCommand.getPrevious();
-        ExecutedCommand next = referencedCommand.getNext();
-
-        if (keyPressed.equals("UP") && previous == null) {
-            return;
-        }
-
-        if (keyPressed.equals("DOWN") && next == null) {
-            commandTextField.setText("");
-            referencedCommand = null;
+        if (history.isEmpty()) {
             return;
         }
 
         if (keyPressed.equals("UP")) {
-            referencedCommand = previous;
+            handleUpKey();
         } else {
-            referencedCommand = next;
+            handleDownKey();
         }
 
-        commandTextField.setText(referencedCommand.getValue());
+        commandTextField.end();
     }
 
     /**

--- a/src/main/java/seedu/recruittrackpro/ui/CommandBox.java
+++ b/src/main/java/seedu/recruittrackpro/ui/CommandBox.java
@@ -35,7 +35,7 @@ public class CommandBox extends UiPart<Region> {
         this.commandExecutor = commandExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
-        commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, this::handleKeyPressed);
+        commandTextField.addEventFilter(KeyEvent.KEY_PRESSED, this::filterKeyPressed);
     }
 
     private void updateCommandHistory(String commandText) {
@@ -54,7 +54,7 @@ public class CommandBox extends UiPart<Region> {
     @FXML
     private void handleCommandEntered() {
         String commandText = commandTextField.getText();
-        if (commandText.equals("")) {
+        if (commandText.isEmpty()) {
             return;
         }
 
@@ -68,8 +68,12 @@ public class CommandBox extends UiPart<Region> {
         }
     }
 
+    /**
+     * Handles the Up arrow button pressed event.
+     */
     private void handleUpKey() {
         if (referenceCommand == null) {
+            // entering the command history
             originalUserInput = commandTextField.getText();
             referenceCommand = commandHistory.getLast();
             commandTextField.setText(referenceCommand.getValue());
@@ -78,30 +82,42 @@ public class CommandBox extends UiPart<Region> {
 
         ExecutedCommand previous = referenceCommand.getPrevious();
         if (previous == null) {
+            // at the head of the command history
             return;
         }
 
+        // in the middle of the command history
         referenceCommand = previous;
         commandTextField.setText(referenceCommand.getValue());
     }
 
+    /**
+     * Handles the Down arrow button pressed event.
+     */
     private void handleDownKey() {
         if (referenceCommand == null) {
+            // outside the command history
             return;
         }
 
         ExecutedCommand next = referenceCommand.getNext();
         if (next == null) {
+            // exiting the command history
             commandTextField.setText(originalUserInput);
             referenceCommand = null;
             return;
         }
 
+        // in the middle of the command history
         referenceCommand = next;
         commandTextField.setText(referenceCommand.getValue());
     }
 
-    private void handleKeyPressed(KeyEvent event) {
+
+    /**
+     * Filters button pressed events.
+     */
+    private void filterKeyPressed(KeyEvent event) {
         String keyPressed = event.getCode().toString();
         if ((!keyPressed.equals("UP") && !keyPressed.equals("DOWN"))) {
             return;
@@ -118,7 +134,7 @@ public class CommandBox extends UiPart<Region> {
             handleDownKey();
         }
 
-        commandTextField.end();
+        commandTextField.end(); // move the text cursor to the end
     }
 
     /**
@@ -154,6 +170,9 @@ public class CommandBox extends UiPart<Region> {
         CommandResult execute(String commandText) throws CommandException, ParseException;
     }
 
+    /**
+     * Represents a string representation of a command that was previously executed.
+     */
     private static class ExecutedCommand {
 
         private final String value;


### PR DESCRIPTION
Fixes #148 

Unfortunately, there will not be any tests accompanying this code change. The code coverage is expected to drop from 79.36% to **77.07%** (-2.29%). As a consolation, I have added some comments in the code to describe the flow.

Reason: The construction of `CommandBox` is coupled with the UI, and there is no easy way to test the logic flow that I added. The only approved third-party testing library is `Mockito` ([ref](https://github.com/nus-cs2103-AY2425S2/forum/issues/118)). Based on what I read in the documentation, it is **not** possible to mock the entire constructor of a class.