### PR TITLE
Unnecessary Horizontal Scroll in List View with Few Records on Minimum Window Size

### DIFF
--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -39,7 +39,7 @@
 
         <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">
           <padding>
-            <Insets top="5" right="10" bottom="5" left="10" />
+            <Insets top="2.5" right="10" bottom="5" left="10" />
           </padding>
         </StackPane>
 


### PR DESCRIPTION
Fixes #164 

Instead of increasing the minimum height of the window, I decided to remove some padding from the command box. This creates just enough space for the list to expand as needed.

## Before
![image](https://github.com/user-attachments/assets/699cafcf-6442-47e2-9141-7157cdf57728)

## After
![image](https://github.com/user-attachments/assets/b0057c90-0a75-42a9-941b-58d51640ba26)
