### PR TITLE
Tags string is incorrectly formatted in person description of result message

### DIFF
--- a/src/main/java/seedu/recruittrackpro/logic/Messages.java
+++ b/src/main/java/seedu/recruittrackpro/logic/Messages.java
@@ -68,8 +68,8 @@ public class Messages {
                 .append(person.getAddress())
                 .append("; Comments: ")
                 .append(person.getComment())
-                .append("; Tags: ");
-        person.getTags().toStream().forEach(builder::append);
+                .append("; Tags: ")
+                .append(person.getTags());
         return builder.toString();
     }
 


### PR DESCRIPTION
Fixes #171 

Refactor the tag output format in result messages. This change affects the messages displayed after executing the add, edit, and delete commands.

<img width="871" alt="image" src="https://github.com/user-attachments/assets/76dd2897-545b-4cb9-9999-5f85a7f95478" />
