### PR TITLE
Fix: Email regex to allow consecutive special chars

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -75,6 +75,12 @@ management tasks done faster than traditional GUI apps.
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
+* For `e/EMAIL`, the email must follow a valid format: `local-part@domain`.
+    - The local-part may include alphanumeric characters and special characters (`.`, `_`, `-`)
+    - It must **not** start or end with a special character
+    - It must **not** contain **consecutive special characters** (e.g., `john..doe@example.com` is invalid)
+    - The domain must contain at least one period, and end with a segment of at least 2 letters
+
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 </box>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -76,11 +76,12 @@ management tasks done faster than traditional GUI apps.
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
 * For `e/EMAIL`, the email must follow a valid format: `local-part@domain`.
-    - The local-part may include alphanumeric characters and special characters (`.`, `_`, `-`)
-    - It must **not** start or end with a special character
-    - It must **not** contain **consecutive special characters** (e.g., `john..doe@example.com` is invalid)
-    - The domain must contain at least one period, and end with a segment of at least 2 letters
-
+  - The local-part may include alphanumeric characters and special characters (`.`, `_`, `-`)
+  - It must **not** start or end with a special character 
+  - It must **not** contain **consecutive special characters** (e.g., `john..doe@example.com` is invalid)
+  - The domain must contain at least one period, and end with a segment of at least 2 letters
+<br>
+<br>
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 </box>
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -77,7 +77,7 @@ management tasks done faster than traditional GUI apps.
 
 * For `e/EMAIL`, the email must follow a valid format: `local-part@domain`.<br>
   The local-part may include alphanumeric characters and special characters (`.`, `_`, `-`), but must **not** start or end with a special character, and must **not** contain **consecutive special characters** (e.g., `john..doe@example.com` is invalid).<br>
-  The domain must contain at least one period, and end with a segment of at least 2 letters.
+  The domain must contain at least one period, and end with a **Top-Level Domain (TLD)** of at least 2 letters.
 
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -75,14 +75,12 @@ management tasks done faster than traditional GUI apps.
 * Extraneous parameters for commands that do not take in parameters (such as `help`, `list`, `exit` and `clear`) will be ignored.<br>
   e.g. if the command specifies `help 123`, it will be interpreted as `help`.
 
-* For `e/EMAIL`, the email must follow a valid format: `local-part@domain`.
-  - The local-part may include alphanumeric characters and special characters (`.`, `_`, `-`)
-  - It must **not** start or end with a special character 
-  - It must **not** contain **consecutive special characters** (e.g., `john..doe@example.com` is invalid)
-  - The domain must contain at least one period, and end with a segment of at least 2 letters
-<br>
-<br>
+* For `e/EMAIL`, the email must follow a valid format: `local-part@domain`.<br>
+  The local-part may include alphanumeric characters and special characters (`.`, `_`, `-`), but must **not** start or end with a special character, and must **not** contain **consecutive special characters** (e.g., `john..doe@example.com` is invalid).<br>
+  The domain must contain at least one period, and end with a segment of at least 2 letters.
+
 * If you are using a PDF version of this document, be careful when copying and pasting commands that span multiple lines as space characters surrounding line-breaks may be omitted when copied over to the application.
+
 </box>
 
 ### Viewing help: `help`

--- a/src/main/java/seedu/recruittrackpro/model/person/Email.java
+++ b/src/main/java/seedu/recruittrackpro/model/person/Email.java
@@ -13,8 +13,9 @@ public class Email {
     public static final String MESSAGE_CONSTRAINTS = "Emails should be of the format local-part@domain "
             + "and adhere to the following constraints:\n"
             + "1. The local-part should only contain alphanumeric characters and these special characters, excluding "
-            + "the parentheses, (" + SPECIAL_CHARACTERS + "). The local-part may not start or end with any special "
-            + "characters.\n"
+            + "the parentheses, (" + SPECIAL_CHARACTERS + ").\n"
+            + "   - The local-part may not start or end with any special characters.\n"
+            + "   - Consecutive special characters are not allowed.\n"
             + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
             + "separated by periods.\n"
             + "The domain name must:\n"
@@ -22,13 +23,11 @@ public class Email {
             + "    - have each domain label start and end with alphanumeric characters\n"
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
 
-    // Local-part: starts and ends with alphanum, allows special characters in between
-    private static final String LOCAL_PART_REGEX = "^[a-zA-Z0-9](?:[a-zA-Z0-9+_.-]*[a-zA-Z0-9])?";
-
-    // Domain label: alphanum start/end, may contain hyphens
+    // alphanumeric and special characters
+    private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
+    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
+            + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_LABEL_REGEX = "[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?";
-
-    // Domain: multiple domain labels separated by dots, ending with TLD (min 2 letters)
     private static final String DOMAIN_REGEX = "(" + DOMAIN_LABEL_REGEX + "\\.)+" + "[a-zA-Z]{2,}";
 
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;

--- a/src/main/java/seedu/recruittrackpro/model/person/Email.java
+++ b/src/main/java/seedu/recruittrackpro/model/person/Email.java
@@ -19,7 +19,7 @@ public class Email {
             + "2. This is followed by a '@' and then a domain name. The domain name is made up of domain labels "
             + "separated by periods.\n"
             + "The domain name must:\n"
-            + "    - end with a domain label at least 2 characters long\n"
+            + "    - end with a Top-Level Domain (TLD) of at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
 

--- a/src/main/java/seedu/recruittrackpro/model/person/Email.java
+++ b/src/main/java/seedu/recruittrackpro/model/person/Email.java
@@ -21,14 +21,16 @@ public class Email {
             + "    - end with a domain label at least 2 characters long\n"
             + "    - have each domain label start and end with alphanumeric characters\n"
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
-    // alphanumeric and special characters
-    private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
-            + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
-            + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";
-    private static final String DOMAIN_LAST_PART_REGEX = "(" + DOMAIN_PART_REGEX + "){2,}$"; // At least two chars
-    private static final String DOMAIN_REGEX = "(" + DOMAIN_PART_REGEX + "\\.)*" + DOMAIN_LAST_PART_REGEX;
+
+    // Local-part: starts and ends with alphanum, allows special characters in between
+    private static final String LOCAL_PART_REGEX = "^[a-zA-Z0-9](?:[a-zA-Z0-9+_.-]*[a-zA-Z0-9])?";
+
+    // Domain label: alphanum start/end, may contain hyphens
+    private static final String DOMAIN_LABEL_REGEX = "[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?";
+
+    // Domain: multiple domain labels separated by dots, ending with TLD (min 2 letters)
+    private static final String DOMAIN_REGEX = "(" + DOMAIN_LABEL_REGEX + "\\.)+" + "[a-zA-Z]{2,}";
+
     public static final String VALIDATION_REGEX = LOCAL_PART_REGEX + "@" + DOMAIN_REGEX;
 
     public final String value;

--- a/src/test/java/seedu/recruittrackpro/model/person/EmailTest.java
+++ b/src/test/java/seedu/recruittrackpro/model/person/EmailTest.java
@@ -44,7 +44,6 @@ public class EmailTest {
         assertFalse(Email.isValidEmail("peter@jack@example.com")); // '@' symbol in local part
         assertFalse(Email.isValidEmail("-peterjack@example.com")); // local part starts with a hyphen
         assertFalse(Email.isValidEmail("peterjack-@example.com")); // local part ends with a hyphen
-        assertFalse(Email.isValidEmail("peter..jack@example.com")); // local part has two consecutive periods
         assertFalse(Email.isValidEmail("peterjack@example@com")); // '@' symbol in domain name
         assertFalse(Email.isValidEmail("peterjack@.example.com")); // domain name starts with a period
         assertFalse(Email.isValidEmail("peterjack@example.com.")); // domain name ends with a period
@@ -57,9 +56,6 @@ public class EmailTest {
         assertTrue(Email.isValidEmail("PeterJack.1190@example.com")); // period in local part
         assertTrue(Email.isValidEmail("PeterJack+1190@example.com")); // '+' symbol in local part
         assertTrue(Email.isValidEmail("PeterJack-1190@example.com")); // hyphen in local part
-        assertTrue(Email.isValidEmail("a@bc")); // minimal
-        assertTrue(Email.isValidEmail("test@localhost")); // alphabets only
-        assertTrue(Email.isValidEmail("123@145")); // numeric local part and domain name
         assertTrue(Email.isValidEmail("a1+be.d@example1.com")); // mixture of alphanumeric and special characters
         assertTrue(Email.isValidEmail("peter_jack@very-very-very-long-example.com")); // long domain name
         assertTrue(Email.isValidEmail("if.you.dream.it_you.can.do.it@example.com")); // long local part
@@ -68,10 +64,10 @@ public class EmailTest {
 
     @Test
     public void equals() {
-        Email email = new Email("valid@email");
+        Email email = new Email("valid@email.com");
 
         // same values -> returns true
-        assertTrue(email.equals(new Email("valid@email")));
+        assertTrue(email.equals(new Email("valid@email.com")));
 
         // same object -> returns true
         assertTrue(email.equals(email));
@@ -83,6 +79,6 @@ public class EmailTest {
         assertFalse(email.equals(5.0f));
 
         // different values -> returns false
-        assertFalse(email.equals(new Email("other.valid@email")));
+        assertFalse(email.equals(new Email("other.valid@email.com")));
     }
 }


### PR DESCRIPTION
**LoC Changed: 17 Line**

Fixes #248 

Updated email validation regex to allow consecutive special characters in the local part, as highlighted in the issue. Also refined the domain regex to ensure valid top-level domain (TLD) handling.